### PR TITLE
Add money icon to price input

### DIFF
--- a/android/app/src/main/java/com/example/budgiet/NewTransaction.kt
+++ b/android/app/src/main/java/com/example/budgiet/NewTransaction.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material3.Button
@@ -149,8 +150,10 @@ fun NewTransactionForm(modifier: Modifier = Modifier) {
                         val errorMsg = "$selectedPrice is not a valid price value"
                         Text(errorMsg)
                     }
-                }
-                // TODO: Add Icon decoration for the price (like $ USD)
+                },
+                leadingIcon = {
+                    Icon(Icons.Filled.AttachMoney, "Currency")
+                },
             )
         }
     }


### PR DESCRIPTION
## Summary
- add a leading money icon to the Price text field so currency is visible

## Changes
- import material AttachMoney icon and set it as leadingIcon on the Price OutlinedTextField

Fixes #6