### PR TITLE
setup: local Android UI tests + GitHub CI for unit tests and instrumented android tests

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [21, 23, 29]
+        api-level: [29, 30, 33]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [29, 30]
+        api-level: [26, 29]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: android
     
   instrumented-tests:
-    timeout-minutes: 10
+    timeout-minutes: 15
     name: Android Instrumented Tests (API ${{ matrix.api-level }})
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [23, 29, 33]
+        api-level: [21, 23, 29]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,7 +15,7 @@ jobs:
     name: Android Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -23,7 +23,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - uses: gradle/actions/setup-gradle@v3
-      - name: run unit tests
+      - name: Run unit tests
         run: ./gradlew test
         working-directory: android
     
@@ -32,16 +32,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [34, 35, 36]
+        api-level: [21, 29, 34]
         profile: ["Pixel 2"] # may add more devices to test later
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      # Enables hardware acceleration for linux runner 
+      # to enhance test execution speed
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -50,7 +53,7 @@ jobs:
 
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v3
-        
+      
       - name: AVD cache
         uses: actions/cache@v4
         id: avd-cache
@@ -60,6 +63,8 @@ jobs:
             ~/.android/adb*
           key: avd-${{ matrix.api-level }}
 
+      # Caches both the android emulator and snapshot (don't have to create
+      # emulator for future runs)
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
@@ -70,11 +75,13 @@ jobs:
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
 
-      - name: run instrumented tests
+      # Runs all instrumented Android Tests
+      - name: Run instrumented tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           profile: ${{ matrix.profile }}
+          arch: x86_64 # note: may add ARM in future 
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -81,7 +81,8 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           profile: ${{ matrix.profile }}
-          arch: x86_64 # note: may add ARM in future 
+          arch: x86_64 # note: may add ARM in future
+          target: aosp
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -33,7 +33,6 @@ jobs:
     strategy:
       matrix:
         api-level: [21, 29, 34]
-        profile: ["Pixel 2"] # may add more devices to test later
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -65,28 +64,22 @@ jobs:
 
       # Caches both the android emulator and snapshot (don't have to create
       # emulator for future runs)
-      - name: create AVD and generate snapshot for caching
+      - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          profile: ${{ matrix.profile }}
           force-avd-creation: false
-          arch: x86_64 # note: may add ARM in future
-          target: aosp
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
 
       # Runs all instrumented Android Tests
-      - name: Run instrumented tests
+      - name: Instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          profile: ${{ matrix.profile }}
-          arch: x86_64 # note: may add ARM in future
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          working-directory: android
-          script: ./gradlew connectedCheck
+          script: ./gradlew connectedDebugAndroidTest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,6 +28,7 @@ jobs:
         working-directory: android
     
   instrumented-tests:
+    timeout-minutes: 10
     name: Android Instrumented Tests (API ${{ matrix.api-level }})
     runs-on: ubuntu-latest
     strategy:
@@ -70,7 +71,7 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot
           disable-animations: false
           working-directory: android
           script: echo "Generated AVD snapshot for caching."
@@ -81,7 +82,10 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot
           disable-animations: true
           working-directory: android
           script: ./gradlew connectedDebugAndroidTest
+      - name: Kill emulator
+        if: always()
+        run: adb emu kill || true

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -82,4 +82,4 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew connectedDebugAndroidTest
+          script: ./gradlew connectedCheck

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -70,7 +70,10 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
+          profile: ${{ matrix.profile }}
           force-avd-creation: false
+          arch: x86_64 # note: may add ARM in future
+          target: aosp
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
@@ -82,7 +85,6 @@ jobs:
           api-level: ${{ matrix.api-level }}
           profile: ${{ matrix.profile }}
           arch: x86_64 # note: may add ARM in future
-          target: aosp
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [21, 23, 29]
+        api-level: [23, 29, 33]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -72,6 +72,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
+          working-directory: android
           script: echo "Generated AVD snapshot for caching."
 
       # Runs all instrumented Android Tests

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,82 @@
+name: Android CI
+
+on:
+  push:
+    paths: 
+      - 'android/**'
+    branches: [ "dev", "main" ]
+  pull_request:
+    branches: [ "dev", "main" ]
+    paths: 
+      - 'android/**'
+
+jobs:
+  unit-tests:
+    name: Android Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - checkout:
+        uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - uses: gradle/actions/setup-gradle@v3
+      - name: run unit tests
+        run: ./gradlew test
+        working-directory: android
+    
+  instrumented-tests:
+    name: Android Instrumented Tests (API ${{ matrix.api-level }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        api-level: [34, 35, 36]
+        profile: ["Pixel 2"] # may add more devices to test later
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+        
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: run instrumented tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          profile: ${{ matrix.profile }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          working-directory: android
+          script: ./gradlew connectedCheck

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [21, 29, 34]
+        api-level: [21, 23, 29]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [29, 30, 33]
+        api-level: [29, 30]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -84,4 +84,4 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           working-directory: android
-          script: ./gradlew connectedCheck
+          script: ./gradlew connectedDebugAndroidTest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -33,7 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [26, 29]
+        # api level 26 and 29 working (30+ not working)
+        # maybe in the future set up so that we test across multiple
+        # api-levels?
+        api-level: [29]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,6 +57,7 @@ jobs:
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v3
       
+      # TODO: Figure out how to cache emulator appropriately
       # - name: AVD cache
       #   uses: actions/cache@v4
       #   id: avd-cache

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -82,4 +82,5 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
+          working-directory: android
           script: ./gradlew connectedCheck

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -54,38 +54,35 @@ jobs:
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v3
       
-      - name: AVD cache
-        uses: actions/cache@v4
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
+      # - name: AVD cache
+      #   uses: actions/cache@v4
+      #   id: avd-cache
+      #   with:
+      #     path: |
+      #       ~/.android/avd/*
+      #       ~/.android/adb*
+      #     key: avd-${{ matrix.api-level }}
 
       # Caches both the android emulator and snapshot (don't have to create
       # emulator for future runs)
-      - name: Create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot
-          disable-animations: false
-          working-directory: android
-          script: echo "Generated AVD snapshot for caching."
+      # - name: Create AVD and generate snapshot for caching
+      #   if: steps.avd-cache.outputs.cache-hit != 'true'
+      #   uses: reactivecircus/android-emulator-runner@v2
+      #   with:
+      #     api-level: ${{ matrix.api-level }}
+      #     force-avd-creation: false
+      #     emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot
+      #     disable-animations: false
+      #     working-directory: android
+      #     script: echo "Generated AVD snapshot for caching."
 
       # Runs all instrumented Android Tests
       - name: Instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          force-avd-creation: false
+          force-avd-creation: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot
           disable-animations: true
           working-directory: android
           script: ./gradlew connectedDebugAndroidTest
-      - name: Kill emulator
-        if: always()
-        run: adb emu kill || true

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,13 +15,13 @@ jobs:
     name: Android Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - checkout:
+      - name: checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '17'
       - uses: gradle/actions/setup-gradle@v3
       - name: run unit tests
         run: ./gradlew test
@@ -37,11 +37,11 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '17'
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -33,11 +33,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "21"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,4 +1,4 @@
-val myMinSdk = 34
+val myMinSdk = 21
 val myTargetSdk = 36
 
 plugins {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,4 +1,4 @@
-val myMinSdk = 21
+val myMinSdk = 29
 val myTargetSdk = 36
 
 plugins {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,4 +1,4 @@
-val myMinSdk = 29
+val myMinSdk = 26
 val myTargetSdk = 36
 
 plugins {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,3 +1,6 @@
+val myMinSdk = 34
+val myTargetSdk = 36
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -7,13 +10,13 @@ plugins {
 android {
     namespace = "com.example.budgiet"
     compileSdk {
-        version = release(36)
+        version = release(myTargetSdk)
     }
 
     defaultConfig {
         applicationId = "com.example.budgiet"
-        minSdk = 24
-        targetSdk = 36
+        minSdk = myMinSdk
+        targetSdk = myTargetSdk
         versionCode = 1
         versionName = "1.0"
 
@@ -30,14 +33,52 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "21"
     }
     buildFeatures {
         compose = true
+    }
+
+    testOptions {
+        managedDevices {
+            localDevices {
+                create("pixel2api34") {
+                    // Use device profiles you typically see in Android Studio.
+                    device = "Pixel 2"
+                    // Use only API levels 34 and higher.
+                    apiLevel = 34
+                    // To include Google services, use "google".
+                    systemImageSource = "aosp"
+                }
+                create("pixel5api35") {
+                    // Use device profiles you typically see in Android Studio.
+                    device = "Pixel 5"
+                    // Use only API levels 34 and higher.
+                    apiLevel = 35
+                    // To include Google services, use "google".
+                    systemImageSource = "aosp"
+                }
+                create("pixel9aapi36") {
+                    // Use device profiles you typically see in Android Studio.
+                    device = "Pixel 9a"
+                    // Use only API levels 34 and higher.
+                    apiLevel = 36
+                    // To include Google services, use "google".
+                    systemImageSource = "aosp"
+                }
+            }
+            groups {
+                create("pixelDevices") {
+                    targetDevices.add(localDevices["pixel2api34"])
+                    targetDevices.add(localDevices["pixel5api35"])
+                    targetDevices.add(localDevices["pixel9aapi36"])
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This PR sets up how gradlew command works in locally testing Android UI tests (operating on "Pixel 2, API 34", "Pixel 5, API 35", and "Pixel 9a, API 36"). These changes are in `app/build.gradle.kt`.

Moreover, we now have a CI script for running any unit tests and instrumented android tests using GitHub Actions (currently operating on a "Pixel 2" via android emulator runner). Fixes #16, #17.