### PR TITLE
chore: Reorganize utils Composables

### DIFF
--- a/android/app/src/androidTest/java/com/example/budgiet/transactionTests/PriceFieldTests.kt
+++ b/android/app/src/androidTest/java/com/example/budgiet/transactionTests/PriceFieldTests.kt
@@ -1,4 +1,4 @@
-package com.example.budgiet
+package com.example.budgiet.transactionTests
 
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
@@ -8,18 +8,18 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
+import com.example.budgiet.MainPage
 import org.junit.Rule
 import org.junit.Test
 
-class TransactionTests {
-
+class PriceFieldTests {
     @get:Rule
     val composeTestRule = createComposeRule()
-    val price_input_node = composeTestRule
+    val priceInputNode = composeTestRule
         .onNodeWithTag("price_input_field")
 
     @Test
-    fun showsPlaceHolderValueOnPriceField() {
+    fun showsPlaceHolderValue() {
         composeTestRule.setContent {
             MainPage()
         }
@@ -33,12 +33,12 @@ class TransactionTests {
         // Note: includeEditableText should be marked as false
         // because we're only checking that the placeholder value
         // is seen (Text = "0", EditableText = "")
-        price_input_node
+        priceInputNode
             .assertTextEquals("0", includeEditableText = false) // placeholder text should be seen
     }
 
     @Test
-    fun enterWholeIntegerOnPriceField() {
+    fun enterWholeInteger() {
         composeTestRule.setContent {
             MainPage()
         }
@@ -49,15 +49,15 @@ class TransactionTests {
                     hasClickAction()
         ).performClick()
 
-        price_input_node
+        priceInputNode
             .performTextInput("100")
 
-        price_input_node
+        priceInputNode
             .assertTextEquals("100")
     }
 
     @Test
-    fun enterDecimalOnPriceField() {
+    fun enterDecimal() {
         composeTestRule.setContent {
             MainPage()
         }
@@ -68,15 +68,15 @@ class TransactionTests {
                     hasClickAction()
         ).performClick()
 
-        price_input_node
+        priceInputNode
             .performTextInput("100.00")
 
-        price_input_node
+        priceInputNode
             .assertTextEquals("100.00")
     }
 
     @Test
-    fun enterInvalidCharacterOnPriceField() {
+    fun enterInvalidCharacter() {
         composeTestRule.setContent {
             MainPage()
         }
@@ -87,20 +87,20 @@ class TransactionTests {
                     hasClickAction()
         ).performClick()
 
-        price_input_node
+        priceInputNode
             .performTextInput("f")
 
 
         // TODO: This needs a screenshot UI test to see a red outline on the box
-        price_input_node
+        priceInputNode
             .assertTextContains("f")
 
-        price_input_node
+        priceInputNode
             .assertTextEquals("f is not a valid price value", includeEditableText = false)
     }
 
     @Test
-    fun enterHalfValidHalfInvalidCharactersPriceField() {
+    fun enterHalfValidHalfInvalidCharacters() {
         composeTestRule.setContent {
             MainPage()
         }
@@ -111,20 +111,20 @@ class TransactionTests {
                     hasClickAction()
         ).performClick()
 
-        price_input_node
+        priceInputNode
             .performTextInput("1")
 
-        price_input_node
+        priceInputNode
             .assertTextEquals("1")
 
-        price_input_node
+        priceInputNode
             .performTextInput("f")
 
         // TODO: This needs a screenshot UI test to see a red outline on the box
-        price_input_node
+        priceInputNode
             .assertTextContains("1f")
 
-        price_input_node
+        priceInputNode
             .assertTextEquals("1f is not a valid price value", includeEditableText = false)
     }
 

--- a/android/app/src/main/java/com/example/budgiet/MainActivity.kt
+++ b/android/app/src/main/java/com/example/budgiet/MainActivity.kt
@@ -29,7 +29,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.example.budgiet.ui.NewTransactionForm
 import com.example.budgiet.ui.theme.BudgietTheme
+import com.example.budgiet.ui.utils.PlainToolTipBox
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/android/app/src/main/java/com/example/budgiet/Utils.kt
+++ b/android/app/src/main/java/com/example/budgiet/Utils.kt
@@ -1,103 +1,18 @@
 package com.example.budgiet
 
 import android.annotation.SuppressLint
-import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.foundation.text.input.rememberTextFieldState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.DockedSearchBar
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.PlainTooltip
-import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.SelectableDates
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextFieldDefaults
-import androidx.compose.material3.TooltipBox
-import androidx.compose.material3.TooltipDefaults
-import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Modifier
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.concurrent.Executors
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun PlainToolTipBox(
-    text: String,
-    modifier: Modifier = Modifier,
-    content: @Composable (() -> Unit)
-) {
-    TooltipBox(
-        modifier = modifier,
-        positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-        state = rememberTooltipState(),
-        tooltip = {
-            PlainTooltip { Text(text) }
-        },
-        content = content,
-    )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun PlainSearchBar(
-    modifier: Modifier = Modifier,
-//    expandable: Boolean = false,
-    onQueryChange: (CharSequence) -> Unit,
-    state: TextFieldState = rememberTextFieldState(),
-) {
-//    var expanded by remember { mutableStateOf(false) }
-//    val onExpandedChange = { new: Boolean ->
-//        expanded = new && expandable
-//    }
-
-    DockedSearchBar(
-        modifier = modifier,
-        expanded = false,
-        onExpandedChange = { },
-        colors = SearchBarDefaults.colors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer,
-        ),
-        inputField = {
-            SearchBarDefaults.InputField(
-                query = state.text.toString(),
-                onQueryChange = {
-                    state.edit { replace(0, length, it) }
-                    onQueryChange(state.text)
-                },
-                onSearch = { },
-                expanded = false,
-                onExpandedChange = { },
-                colors = TextFieldDefaults.colors(
-                    focusedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                    unfocusedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                ),
-                placeholder = { Text("Search existing locations") },
-                leadingIcon = { Icon(Icons.Filled.Search, null) },
-                trailingIcon = if (state.text.isNotEmpty()) { {
-                    PlainToolTipBox("Clear search") {
-                        IconButton(onClick = { state.edit { replace(0, length, "") } }) {
-                            Icon(Icons.Filled.Clear, "Clear search")
-                        }
-                    }
-                } } else {
-                    null
-                },
-            )
-        }
-    ) { }
-}
 
 /** An [Executor][java.util.concurrent.Executor] containing the *single thread* that will run *blocking tasks*.
  *

--- a/android/app/src/main/java/com/example/budgiet/ui/NewTransaction.kt
+++ b/android/app/src/main/java/com/example/budgiet/ui/NewTransaction.kt
@@ -1,9 +1,8 @@
-package com.example.budgiet
+package com.example.budgiet.ui
 
 import android.graphics.Color
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -11,33 +10,25 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.DateRange
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
-import androidx.compose.material3.DividerDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.LocalTextStyle
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -50,29 +41,35 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.paging.LoadState
 import androidx.paging.PagingConfig
-import androidx.paging.compose.collectAsLazyPagingItems
-import androidx.paging.compose.itemKey
+import com.example.budgiet.Date
+import com.example.budgiet.Location
+import com.example.budgiet.Result
+import com.example.budgiet.getLocationsSearchPage
+import com.example.budgiet.getRecentLocations
+import com.example.budgiet.rememberListPager
+import com.example.budgiet.rememberWork
 import com.example.budgiet.ui.theme.BudgietTheme
+import com.example.budgiet.ui.utils.ListColumn
+import com.example.budgiet.ui.utils.ListItemScope
+import com.example.budgiet.ui.utils.PagedListColumn
+import com.example.budgiet.ui.utils.PagerController
+import com.example.budgiet.ui.utils.PlainSearchBar
+import com.example.budgiet.ui.utils.PlainToolTipBox
 import kotlin.math.ceil
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NewTransactionForm(modifier: Modifier = Modifier) {
     var showDatePicker by remember { mutableStateOf(false) }
-    var selectedDate by remember { mutableStateOf(Date.now()) }
+    var selectedDate by remember { mutableStateOf(Date.Companion.now()) }
     var showLocationPicker by remember { mutableStateOf(false) }
     var selectedLocation by remember { mutableStateOf<Location?>(null) }
     var selectedPrice by remember { mutableStateOf("") }
@@ -161,7 +158,7 @@ fun NewTransactionForm(modifier: Modifier = Modifier) {
 
     if (showDatePicker) {
         val datePickerState = rememberDatePickerState(
-            selectableDates = Date.pastOrPresentDates(),
+            selectableDates = Date.Companion.pastOrPresentDates(),
         )
 
         DatePickerDialog(
@@ -244,26 +241,12 @@ fun LocationPickerDialog(
     val dialogPadding = 8.dp
     val textIconButtonPadding = 12.dp
     val textIconButtonSpacing = 4.dp
-    val dividerThickness = DividerDefaults.Thickness
-    // How many items should fit in the LazyColumn Widget (in terms of a list item's height)
-    val searchColumnSize = 3.5
+    val searchColumnSize = 3.5f
     // Page size should have enough items to scroll down several times the number of items showed.
     val searchPageSize = ceil(searchColumnSize).toInt() * 3
     val searchState = rememberTextFieldState()
 
-    val searchPager = rememberListPager(
-        searchState = searchState,
-        getPage = { query, start, len -> getLocationsSearchPage(query, start, len) },
-        config = PagingConfig(
-            pageSize = searchPageSize,
-            initialLoadSize = searchPageSize,
-            // Must be > pageSize * 3, let's make it 4 pages.
-            maxSize = searchPageSize * 4,
-            // Don't let the pager return a bunch of unloaded items, we are going to show a single unloaded item at a time.
-            enablePlaceholders = false,
-        )
-    )
-    val pagedItems = searchPager.flow.collectAsLazyPagingItems()
+    val searchPagerController = remember { PagerController() }
     // These are the items shown if the search does not have a query
     val recentItems by rememberWork { getRecentLocations() }
 
@@ -284,7 +267,7 @@ fun LocationPickerDialog(
             ) {
                 // TODO: cancel getPage when the clear button is clicked
                 PlainSearchBar(
-                    onQueryChange = { pagedItems.refresh() },
+                    onQueryChange = { searchPagerController.refresh() },
                     state = searchState,
                 )
 
@@ -299,109 +282,54 @@ fun LocationPickerDialog(
                     Spacer(Modifier.height(dialogPadding))
                 }
 
-                val localDensity = LocalDensity.current
-                // Get the height of the first item in the list to determine the size of the whole List widget.
-                var itemHeight by remember { mutableStateOf<Dp?>(null) }
-                // Have a default in case the item's height could not be obtained.
-                val defaultItemHeight = 70.5.dp
-
                 @Composable
-                fun LocationItem(location: Location, modifier: Modifier = Modifier) {
-                    ListItem(
-                        modifier = modifier
-                            .onGloballyPositioned { coords ->
-                                // Only set the height for the first rendered element
-                                if (itemHeight == null) {
-                                    itemHeight = with(localDensity) { coords.size.height.toDp() }
-                                }
-                            }
-                            .clip(RoundedCornerShape(4.dp))
-                            .clickable(onClick = { onSubmit(location) }),
+                fun ListItemScope.LocationItem(location: Location) {
+                    this.DataItem(
+                        modifier = modifier.clickable(onClick = { onSubmit(location) }),
                         headlineContent = { Text(location.name) },
                         supportingContent = { Text(location.address) },
                     )
                 }
 
-                @Composable
-                fun LoadingItem(modifier: Modifier = Modifier) {
-                    Box(contentAlignment = Alignment.Center) {
-                        ListItem(
-                            modifier = modifier
-                                .heightIn(min = itemHeight ?: defaultItemHeight)
-                                .clip(RoundedCornerShape(4.dp)),
-                            headlineContent = { }
-                        )
-                        CircularProgressIndicator()
-                    }
-                }
-                @Composable
-                fun ErrorItem(type: String, message: String? = null, modifier: Modifier = Modifier) {
-                    val color = MaterialTheme.colorScheme.error
-                    ListItem(
-                        // This item does not need to be resized,
-                        // but it should also not set the List height because it has an irregular size due to the error message.
-                        modifier = modifier,
-                        leadingContent = { Icon(
-                            Icons.Filled.Info, // TODO: replace with the Material Error icon
-                            "Error",
-                            tint = color,
-                        ) },
-                        headlineContent = { Text("Error: $type", color = color) },
-                        supportingContent = message?.let { { Text(message, color = color) } }
-                    )
-                }
-
-                LazyColumn(
-                    verticalArrangement = Arrangement.spacedBy(dividerThickness),
-                    modifier = Modifier.clip(RoundedCornerShape(16.dp))
-                        // List's height should be conscious of it's items' and dividers' heights.
-                        // TODO: use clamp
-                        .heightIn(max = (itemHeight ?: defaultItemHeight) * searchColumnSize.toFloat() + dividerThickness * 3),
-                ) {
-                    // Show search results if the SearchBar has a query,
-                    // otherwise show recent locations
-                    if (searchState.text.isEmpty()) {
+                // Show search results if the SearchBar has a query,
+                // otherwise show recent locations
+                if (searchState.text.isEmpty()) {
+                    ListColumn(visibleItems = searchColumnSize) {
                         when (recentItems) {
                             is Result.Ok -> {
-                                items((recentItems as Result.Ok).value,
-                                    key = { location -> location.id.toInt() } // Why can't use UInt ....
-                                ) { location ->
-                                    LocationItem(location)
-                                }
+                                items(
+                                    items = (recentItems as com.example.budgiet.Result.Ok).value,
+                                    key = { location -> location.id.toInt() }, // Why can't use UInt ....
+                                ) { location -> this.LocationItem(location) }
                             }
                             // Show the item as an Error if the task threw an Exception
                             is Result.Err -> {
                                 val error = (recentItems as Result.Err).error
-                                item { ErrorItem(error.javaClass.name, error.localizedMessage) }
+                                item { this.ErrorItem(type = error.javaClass.name, message = error.localizedMessage) }
                             }
                             // Show loading indicator while the items are being obtained
-                            null -> item { LoadingItem() }
-                        }
-                    } else {
-                        if (pagedItems.loadState.prepend == LoadState.Loading) {
-                            item { LoadingItem() }
-                        }
-
-                        if (pagedItems.loadState.refresh == LoadState.Loading) {
-                            item { LoadingItem() }
-                        } else {
-                            items(pagedItems.itemCount,
-                                key = pagedItems.itemKey { location -> location.id.toInt() }
-                            ) { index ->
-                                pagedItems[index]?.let { location ->
-                                    LocationItem(location)
-                                } ?: run {
-                                    // This will never be null as long as enablePlaceholders = false in the Pager.
-                                    // Leave it here tho, in case we change it to true and forget about it.
-                                    LoadingItem()
-                                }
-                            }
-                        }
-
-                        if (pagedItems.loadState.append == LoadState.Loading) {
-                            item { LoadingItem() }
+                            null -> item { this.LoadingItem() }
                         }
                     }
+                } else {
+                    PagedListColumn(
+                        visibleItems = searchColumnSize,
+                        pager = rememberListPager(
+                            searchState = searchState,
+                            getPage = { query, start, len -> getLocationsSearchPage(query, start, len) },
+                            config = PagingConfig(
+                                pageSize = searchPageSize,
+                                initialLoadSize = searchPageSize,
+                                // Must be > pageSize * 3, let's make it 4 pages.
+                                maxSize = searchPageSize * 4,
+                                // Don't let the pager return a bunch of unloaded items, we are going to show a single unloaded item at a time.
+                                enablePlaceholders = false,
+                            )
+                        ),
+                        pagerController = searchPagerController,
+                        itemKey = { location -> location.id.toInt() },
+                        itemContent = { location -> this.LocationItem(location) }
+                    )
                 }
 
                 Row(

--- a/android/app/src/main/java/com/example/budgiet/ui/NewTransaction.kt
+++ b/android/app/src/main/java/com/example/budgiet/ui/NewTransaction.kt
@@ -69,7 +69,7 @@ import kotlin.math.ceil
 @Composable
 fun NewTransactionForm(modifier: Modifier = Modifier) {
     var showDatePicker by remember { mutableStateOf(false) }
-    var selectedDate by remember { mutableStateOf(Date.Companion.now()) }
+    var selectedDate by remember { mutableStateOf(Date.now()) }
     var showLocationPicker by remember { mutableStateOf(false) }
     var selectedLocation by remember { mutableStateOf<Location?>(null) }
     var selectedPrice by remember { mutableStateOf("") }
@@ -158,7 +158,7 @@ fun NewTransactionForm(modifier: Modifier = Modifier) {
 
     if (showDatePicker) {
         val datePickerState = rememberDatePickerState(
-            selectableDates = Date.Companion.pastOrPresentDates(),
+            selectableDates = Date.pastOrPresentDates(),
         )
 
         DatePickerDialog(
@@ -298,7 +298,7 @@ fun LocationPickerDialog(
                         when (recentItems) {
                             is Result.Ok -> {
                                 items(
-                                    items = (recentItems as com.example.budgiet.Result.Ok).value,
+                                    items = (recentItems as Result.Ok).value,
                                     key = { location -> location.id.toInt() }, // Why can't use UInt ....
                                 ) { location -> this.LocationItem(location) }
                             }

--- a/android/app/src/main/java/com/example/budgiet/ui/utils/Common.kt
+++ b/android/app/src/main/java/com/example/budgiet/ui/utils/Common.kt
@@ -1,0 +1,101 @@
+// This file (and the utils package) contains miscellaneous UI Composables that act as helpers of other Composables.
+package com.example.budgiet.ui.utils
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.DockedSearchBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/** A shortcut for adding a [PlainTooltip] to some **content**.
+ *
+ * When the user activates the [PlainTooltip] (i.e. by long-pressing the **content**),
+ * the **text** passed in will pup up with a box around it. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PlainToolTipBox(
+    text: String,
+    modifier: Modifier = Modifier,
+    content: @Composable (() -> Unit)
+) {
+    TooltipBox(
+        modifier = modifier,
+        positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+        state = rememberTooltipState(),
+        tooltip = {
+            PlainTooltip { Text(text) }
+        },
+        content = content,
+    )
+}
+
+/** A [SearchBar][DockedSearchBar] that *does not* expand to show its result items.
+ * Instead, the items must be placed in a different composable.
+ *
+ * The caller must update the search results when a *change in input* has been detected.
+ * This is done through the **onQueryChange** Callback, which provides the *new search input*.
+ *
+ * The caller can also provide their own [TextFieldState] if they want to have control over the *search input*. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PlainSearchBar(
+    modifier: Modifier = Modifier,
+//    expandable: Boolean = false,
+    onQueryChange: (CharSequence) -> Unit,
+    state: TextFieldState = rememberTextFieldState(),
+) {
+//    var expanded by remember { mutableStateOf(false) }
+//    val onExpandedChange = { new: Boolean ->
+//        expanded = new && expandable
+//    }
+
+    DockedSearchBar(
+        modifier = modifier,
+        expanded = false,
+        onExpandedChange = { },
+        colors = SearchBarDefaults.colors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+        ),
+        inputField = {
+            SearchBarDefaults.InputField(
+                query = state.text.toString(),
+                onQueryChange = {
+                    state.edit { replace(0, length, it) }
+                    onQueryChange(state.text)
+                },
+                onSearch = { },
+                expanded = false,
+                onExpandedChange = { },
+                colors = TextFieldDefaults.colors(
+                    focusedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    unfocusedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
+                placeholder = { Text("Search existing locations") },
+                leadingIcon = { Icon(Icons.Filled.Search, null) },
+                trailingIcon = if (state.text.isNotEmpty()) { {
+                    PlainToolTipBox("Clear search") {
+                        IconButton(onClick = { state.edit { replace(0, length, "") } }) {
+                            Icon(Icons.Filled.Clear, "Clear search")
+                        }
+                    }
+                } } else {
+                    null
+                },
+            )
+        }
+    ) { }
+}

--- a/android/app/src/main/java/com/example/budgiet/ui/utils/Lists.kt
+++ b/android/app/src/main/java/com/example/budgiet/ui/utils/Lists.kt
@@ -1,0 +1,376 @@
+package com.example.budgiet.ui.utils
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DividerDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemColors
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.paging.LoadState
+import androidx.paging.Pager
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.itemKey
+import com.example.budgiet.PagingKey
+import com.example.budgiet.rememberListPager
+
+/** When a [LazyColumn]'s [ListItem]'s **height** can't be determined because it has no content,
+ * use this value for the **height** instead. */
+private val LIST_ITEM_DEFAULT_HEIGHT = 70.5.dp
+val LIST_SHAPE = RoundedCornerShape(16.dp)
+val LIST_ITEM_SHAPE = RoundedCornerShape(4.dp)
+const val LIST_DEFAULT_VISIBLE_ITEMS = 3.5f
+
+/** Receiver scope for [ListColumn].
+ *
+ * Emulates the same interface as [LazyListScope],
+ * but instead exposes a custom [ListItemScope],
+ * which itself exposes the correct composable items to use in [ListColumn]. */
+class ListColumnScope internal constructor(
+    private val innerScope: LazyListScope,
+    /** Determines the height of the whole list,
+     * and also sets the height of *list items* that don't know what their height should be. */
+    internal val itemHeight: MutableState<Dp?>,
+    internal val itemShape: Shape,
+) {
+    @Suppress("unused")
+    /** See [LazyListScope.item]. */
+    fun item(
+        key: Any? = null,
+        contentType: Any? = null,
+        content: @Composable ListItemScope.() -> Unit,
+    ) = this.innerScope.item(key, contentType) { newListItemScope(this).content() }
+
+    @Suppress("unused")
+    /** See [LazyListScope.items] (overload with **count**). */
+    fun items(
+        count: Int,
+        key: ((index: Int) -> Any)? = null,
+        contentType: (index: Int) -> Any? = { null },
+        itemContent: @Composable ListItemScope.(index: Int) -> Unit,
+    ) = this.innerScope.items(count, key, contentType) { i ->
+        newListItemScope(this).itemContent(i)
+    }
+
+    @Suppress("unused")
+    /** See [LazyListScope.items] (overload with [List]). */
+    fun <T> items(
+        items: List<T>,
+        key: ((item: T) -> Any)? = null,
+        contentType: (item: T) -> Any? = { null },
+        itemContent: @Composable ListItemScope.(item: T) -> Unit,
+    ) = this.innerScope.items(items, key, contentType) { item ->
+        newListItemScope(this).itemContent(item)
+    }
+
+    @Suppress("unused")
+    /** See [LazyListScope.itemsIndexed]. */
+    fun <T> itemsIndexed(
+        items: List<T>,
+        key: ((Int, T) -> Any)? = null,
+        contentType: (Int, T) -> Any? = { _, _ -> null },
+        itemContent: @Composable ListItemScope.(Int, T) -> Unit,
+    ) = this.innerScope.itemsIndexed(items, key, contentType) { i, item ->
+        newListItemScope(this).itemContent(i, item)
+    }
+
+    private fun newListItemScope(innerScope: LazyItemScope) = ListItemScope(innerScope, this)
+}
+
+/** A custom [LazyItemScope], which exposes the composables that should be used in [ListColumn].
+ * All composables in here are implemented with [ListItem].
+ *
+ * * **[DataItem]**: Represents *good data* in the list.
+ *
+ * * **[LoadingItem]**: Renders an item with a **progress indicator** composable as the content,
+ *     indicating that the [ListColumn] is waiting for more items to **load**.
+ *
+ *     This is primarily used in the [PagedListColumn].
+ *
+ * * **[ErrorItem]**: Represents *bad data* in the list.
+ *
+ *     This occurs when an **Exception** is thrown when an item is being fetched.
+ *     For example, when the [Pager] attempts to load a page, but the loader throws. */
+class ListItemScope internal constructor(
+    private val innerScope: LazyItemScope,
+    private val listScope: ListColumnScope,
+) : LazyItemScope {
+    /** Represents *good data* in the [ListColumn]. */
+    @Composable
+    fun DataItem(
+        headlineContent: @Composable (() -> Unit),
+        modifier: Modifier = Modifier,
+        overlineContent: @Composable (() -> Unit)? = null,
+        supportingContent: @Composable (() -> Unit)? = null,
+        leadingContent: @Composable (() -> Unit)? = null,
+        trailingContent: @Composable (() -> Unit)? = null,
+        colors: ListItemColors = ListItemDefaults.colors(),
+        tonalElevation: Dp = ListItemDefaults.Elevation,
+        shadowElevation: Dp = ListItemDefaults.Elevation
+    ) {
+        val localDensity = LocalDensity.current
+
+        ListItem(
+            headlineContent = headlineContent,
+            modifier = modifier
+                .onGloballyPositioned { coords ->
+                    // Only set the height for the first rendered element
+                    if (this.listScope.itemHeight.value == null) {
+                        this.listScope.itemHeight.value = with(localDensity) { coords.size.height.toDp() }
+                    }
+                }
+                .clip(this.listScope.itemShape),
+            overlineContent = overlineContent,
+            supportingContent = supportingContent,
+            leadingContent = leadingContent,
+            trailingContent = trailingContent,
+            colors = colors,
+            tonalElevation = tonalElevation,
+            shadowElevation = shadowElevation,
+        )
+    }
+    /** Renders an item with a **progress indicator** composable as the content,
+     * indicating that the [ListColumn] is waiting for more items to **load**.
+     *
+     * This is primarily used in the [PagedListColumn]. */
+    @Composable
+    fun LoadingItem(
+        modifier: Modifier = Modifier,
+        progressIndicator: @Composable () -> Unit = { CircularProgressIndicator() },
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            DataItem(
+                modifier = modifier
+                    .heightIn(min = listScope.itemHeight.value ?: LIST_ITEM_DEFAULT_HEIGHT)
+                    .clip(LIST_ITEM_SHAPE),
+                headlineContent = { }
+            )
+            progressIndicator()
+        }
+    }
+    /** Represents *bad data* in the [ListColumn].
+     *
+     * This occurs when an **Exception** is thrown when an item is being fetched.
+     * For example, when the [Pager] attempts to load a page, but the loader throws. */
+    @Composable
+    fun ErrorItem(modifier: Modifier = Modifier, type: String, message: String? = null) {
+        val color = MaterialTheme.colorScheme.error
+        DataItem(
+            // This item does not need to be resized,
+            // but it should also not set the List height because it has an irregular size due to the error message.
+            modifier = modifier.clip(this.listScope.itemShape),
+            leadingContent = { Icon(
+                Icons.Filled.Info, // TODO: replace with the Material Error icon
+                "Error",
+                tint = color,
+            ) },
+            headlineContent = { Text("Error: $type", color = color) },
+            supportingContent = message?.let { { Text(message, color = color) } }
+        )
+    }
+
+    override fun Modifier.fillParentMaxHeight(fraction: Float): Modifier
+            = this@ListItemScope.innerScope::class.java.getMethod("fillParentMaxHeight").invoke(this, fraction) as Modifier
+    override fun Modifier.fillParentMaxSize(fraction: Float): Modifier
+            = this@ListItemScope.innerScope::class.java.getMethod("fillParentMaxSize").invoke(this, fraction) as Modifier
+    override fun Modifier.fillParentMaxWidth(fraction: Float): Modifier
+            = this@ListItemScope.innerScope::class.java.getMethod("fillParentMaxWidth").invoke(this, fraction) as Modifier
+}
+
+/** A [LazyColumn] that uses custom composables for the **items**,
+ * giving the [LazyColumn] a more proper *"list" look*.
+ *
+ * See [ListItemScope] for details on these composables.
+ *
+ * @param state The state object to be used to control or observe the list's state.
+ *   May be omitted if the caller is not interested in handling the list's state.
+ * @param contentPadding Apply padding to the **content** of the list as a whole,
+ *   *not* each individual item.
+ *   This essentially allows adding padding to the *sides* of all items,
+ *   *top* of the *first* item, and *bottom* of the *last* item.
+ * @param reverseLayout See [LazyColumn].
+ * @param visibleItems How many *list items* should be visible at a time.
+ *   Essentially sets the [ListColumn]'s **height** in terms of its **items**'s heights.
+ * @param shape The [Shape] around the list widget.
+ *   This allows setting the **roundness** of the list's corners.
+ * @param itemShape The [Shape] around individual **items** in the list.
+ *   This allows setting the **roundness** of the corners of all items.
+ *   This value only has an effect if an **item** is using one of the composables in [ListItemScope].
+ * @param dividerThickness How much **spacing** should be applied between each item in the list.
+ * @param content The space to declare the items in the list.
+ *   Use [LazyListScope.item] or [LazyListScope.items],
+ *   and within those call one of the composables in [ListItemScope]. */
+@Composable
+fun ListColumn(
+    modifier: Modifier = Modifier,
+    state: LazyListState = rememberLazyListState(),
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    reverseLayout: Boolean = false,
+    visibleItems: Float = LIST_DEFAULT_VISIBLE_ITEMS,
+    shape: Shape = LIST_SHAPE,
+    itemShape: Shape = LIST_ITEM_SHAPE,
+    dividerThickness: Dp = DividerDefaults.Thickness,
+    content: ListColumnScope.() -> Unit
+) {
+    // Get the height of the first item in the list to determine the size of the whole List widget.
+    val itemHeight = remember { mutableStateOf<Dp?>(null) }
+    val listMaxHeight = (itemHeight.value ?: LIST_ITEM_DEFAULT_HEIGHT) * visibleItems + dividerThickness * 3
+
+    LazyColumn(
+        state = state,
+        contentPadding = contentPadding,
+        reverseLayout = reverseLayout,
+        verticalArrangement = Arrangement.spacedBy(dividerThickness),
+        // List's height should be conscious of it's items' and dividers' heights.
+        // TODO: use clamp
+        modifier = modifier.heightIn(max = listMaxHeight)
+            .clip(shape),
+    ) { ListColumnScope(this, itemHeight, itemShape).content() }
+}
+
+/** Contains methods that allow *checking* and *controlling* the state of a [Pager].
+ *
+ * The controller is *bound* to a [Pager] after it is passed to a [Composable] that uses a [Pager].
+ * Before the controller is *bound* none of its methods will have any effect and will return *default values*. */
+class PagerController internal constructor() {
+    private lateinit var _items: LazyPagingItems<*>
+    private lateinit var pager: Pager<PagingKey, *>
+
+    /** Initializes the controller to operate on the provided [Pager] **items**. */
+    @SuppressLint("ComposableNaming")
+    @Composable
+    internal fun <T: Any> bind(pager: Pager<PagingKey, T>) {
+        if (itemsNullable == null) {
+            this.pager = pager
+            this._items = pager.flow.collectAsLazyPagingItems()
+        }
+    }
+
+    /** Don't forget to call [bind] before reading from this value!
+     *
+     * @throws IllegalArgumentException if the caller does not use the same pager that this controller was bound to.
+     * @throws UninitializedPropertyAccessException if this controller has not been bound to a pager yet. */
+    internal fun <T: Any> items(pager: Pager<PagingKey, T>): LazyPagingItems<T> {
+        if (this.pager !== pager) {
+            throw IllegalArgumentException("Used a different pager than the one that this controller was bound to")
+        }
+        /* SAFETY: This cast will always work because _items is tied to the pager,
+         * so they're going to have the same `T`,
+         * and the values never change after they're initialized.
+         * */
+        @Suppress("UNCHECKED_CAST")
+        return this._items as LazyPagingItems<T>
+    }
+
+    /** Exposed methods MUST use this instead of [items]. */
+    private val itemsNullable: LazyPagingItems<*>?
+        get() = if (this::_items.isInitialized) { this._items } else { null }
+
+    /** Trigger a **refresh* in the [Pager]'s data,
+     * invalidating *all loaded items* in the [Pager].
+     *
+     * Wrapper for [LazyPagingItems.refresh]. */
+    fun refresh() = this.itemsNullable?.refresh()
+
+    /** Check if the [Pager] is still *loading* items that are being **prepended** to the list. */
+    val prependLoading: Boolean
+        get() = this.itemsNullable?.let { it.loadState.prepend == LoadState.Loading } ?: false
+    /** Check if the [Pager] is still *loading* items after a [refresh]. */
+    val refreshLoading: Boolean
+        get() = this.itemsNullable?.let { it.loadState.refresh == LoadState.Loading } ?: false
+    /** Check if the [Pager] is still *loading* items that are being **appended** to the list. */
+    val appendLoading: Boolean
+        get() = this.itemsNullable?.let { it.loadState.append == LoadState.Loading } ?: false
+}
+
+/** A [ListColumn] that uses a [Pager] to load items.
+ *
+ * See [ListColumn] for the rest of the *parameters*.
+ *
+ * @param pager The [Pager] is responsible for *loading* and *unloading* the data.
+ *
+ *   Since the [Pager] itself doesn't expose any methods to check state or read items,
+ *   the caller must provide a [PagerController] to do any of that.
+ *   If the caller is not interested in having any control over the [Pager],
+ *   they may omit the **pagerController** argument, and an *inaccessible* [PagerController] will be used.
+ *
+ *   See [rememberListPager] of how to create a [Pager] in a composable.
+ *
+ * @param pagerController Allows the caller to trigger a *[refresh][PagerController.refresh]* on the [Pager]'s data.
+ * @param itemKey A Callback that generates an *unique key* for every **item**. See [LazyListScope.items].
+ * @param itemContent The [Composable] that will be called for *each item* in the [Pager]'s data.
+ *   The caller *should* use [ListItemScope.DataItem], but it is not required. */
+@Composable
+fun <T: Any> PagedListColumn(
+    modifier: Modifier = Modifier,
+    state: LazyListState = rememberLazyListState(),
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    reverseLayout: Boolean = false,
+    visibleItems: Float = LIST_DEFAULT_VISIBLE_ITEMS,
+    shape: Shape = LIST_SHAPE,
+    itemShape: Shape = LIST_ITEM_SHAPE,
+    dividerThickness: Dp = DividerDefaults.Thickness,
+    pager: Pager<PagingKey, T>,
+    pagerController: PagerController = remember { PagerController() },
+    itemKey: (T) -> Any,
+    itemContent: @Composable ListItemScope.(T) -> Unit,
+) {
+    pagerController.bind(pager)
+
+    ListColumn(modifier, state, contentPadding, reverseLayout, visibleItems, shape, itemShape, dividerThickness) {
+        if (pagerController.prependLoading) {
+            item { this.LoadingItem() }
+        }
+
+        if (pagerController.refreshLoading) {
+            item { this.LoadingItem() }
+        } else {
+            // TODO: Make ListPagingSource expose items as Result so we can handle when a page throws an Exception.
+            val items = pagerController.items(pager)
+            this.items(items.itemCount,
+                key = items.itemKey { item -> itemKey(item) }
+            ) { item ->
+                items[item]?.let { item ->
+                    this.itemContent(item)
+                } ?: run {
+                    // This will never be null as long as enablePlaceholders = false in the Pager.
+                    // Leave it here tho, in case we change it to true and forget about it.
+                    this.LoadingItem()
+                }
+            }
+        }
+
+        if (pagerController.appendLoading) {
+            item { this.LoadingItem() }
+        }
+    }
+}


### PR DESCRIPTION
> Note: Going forward, all Composables that are UI components in the app must go in the `ui` module.

 * Moved `PlainToolTipBox` and `PlainSearchBar` from `/Utils.kt` to `/ui/utils/Common.kt`
   * Also added doc comments for those items.
 * Moved `NewTransactionForm` to the `ui` module.
 * Moved the code for the **paged** items in the `LocationPickerDialog` out of `NewTransactionForm.kt` and into `/ui/utils/List.kt`.
   * Split the `LazyColumn` into 2 components: `ListColumn` and `PagedListColumn`. The former is a light wrapper around `LazyColumn` but with a customized style, and the latter is a `ListColumn` for use with a `Pager`.
   * The `PagedListColumn` is generic, so the old code can now be used with any `Pager`.
     * It also has a `PagerController` that allows constructing the pager within the function call while being able to call `refresh()` form anywhere.