### PR TITLE
fix: DatePicker displaying incorrect dates / throwing exception

### DIFF
--- a/android/app/src/main/java/com/example/budgiet/Utils.kt
+++ b/android/app/src/main/java/com/example/budgiet/Utils.kt
@@ -9,7 +9,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
+import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.concurrent.Executor
@@ -178,57 +180,28 @@ suspend fun <T> runWork(executor: Executor = WORKER_THREAD, task: suspend () -> 
     }
 }
 
-// Formatting method taken from https://stackoverflow.com/a/56668796/32115191.
-// According to the answer, the java.time package can be used in any version of Android, so the warning can be suppressed.
-@SuppressLint("NewApi")
-class Date private constructor(private val localDate: LocalDate) {
-    constructor(millis: Long) : this(
-        java.util.Date(millis).let { dateMillis ->
-            LocalDate.of(dateMillis.year, dateMillis.month, dateMillis.date)
-        }
-    )
+fun localDateFromUtcMillis(utcMillis: Long): LocalDate {
+    return Instant.ofEpochMilli(utcMillis)
+        // NOTE: This does not set the timezone of the Date to UTC,
+        // but instead interprets the millis as set in UTC, which is what the DatePicker provides.
+        .atZone(ZoneOffset.UTC)
+        .toLocalDate()
+}
+fun LocalDate.formatRelativeToPresent(): String {
+    val now = LocalDate.now()
 
-    override fun toString(): String {
-        val now = LocalDate.now()
-        println("localDate = $localDate")
-        println("now = $now")
-
-        return if (localDate == now) {
-            "Today"
-        } else if (localDate == now.minusDays(1)) {
-            "Yesterday"
-        } else {
-            val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG)
-            localDate.format(formatter)
-        }
-    }
-
-    companion object {
-        /** Get the **current** [Date].
-         *
-         * Calls [LocalDate.now] under the hood. */
-        fun now(): Date {
-            return Date(LocalDate.now())
-        }
-
-        /** Only allow [Date]s that occurred.
-         * That is, dates that are in the *past or present*.
-         *
-         * @return a singleton that can be passed to [rememberDatePickerState][androidx.compose.material3.rememberDatePickerState],
-         * which will disable any *future* dates in the [DatePicker][androidx.compose.material3.DatePicker],
-         * only allowing *past or present* dates to be selected. */
-        @OptIn(ExperimentalMaterial3Api::class)
-        fun pastOrPresentDates(): SelectableDates {
-            // Taken from https://stackoverflow.com/a/77678547/32115191
-            return object : SelectableDates {
-                override fun isSelectableDate(utcTimeMillis: Long): Boolean {
-                    return utcTimeMillis <= System.currentTimeMillis()
-                }
-                override fun isSelectableYear(year: Int): Boolean {
-                    return year <= LocalDate.now().year
-                }
+    return when (this) {
+        // I know this arm is unreachable, but wanted to include it for completeness.
+        // Maybe we'll want to use it for something else later.
+        now.plusDays(1) -> "Tomorrow"
+        now -> "Today"
+        now.minusDays(1) -> "Yesterday"
+        // Formatting method taken from https://stackoverflow.com/a/56668796/32115191.
+        else -> DateTimeFormatter
+            .ofLocalizedDate(FormatStyle.LONG)
+            .let { formatter ->
+                this.format(formatter)
             }
-        }
     }
 }
 

--- a/android/app/src/main/java/com/example/budgiet/ui/NewTransaction.kt
+++ b/android/app/src/main/java/com/example/budgiet/ui/NewTransaction.kt
@@ -53,10 +53,10 @@ import androidx.compose.ui.unit.em
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.paging.PagingConfig
-import com.example.budgiet.Date
 import com.example.budgiet.Location
 import com.example.budgiet.R
 import com.example.budgiet.Result
+import com.example.budgiet.formatRelativeToPresent
 import com.example.budgiet.getLocationsSearchPage
 import com.example.budgiet.getRecentLocations
 import com.example.budgiet.graphemeStringLength
@@ -74,6 +74,7 @@ import com.example.budgiet.ui.utils.PagerController
 import com.example.budgiet.ui.utils.PlainSearchBar
 import com.example.budgiet.ui.utils.PlainToolTipBox
 import com.example.budgiet.ui.utils.TextIconButton
+import java.time.LocalDate
 import java.util.Currency
 import kotlin.math.ceil
 
@@ -87,7 +88,7 @@ val DESCRIPTION_FIELD_MAX_HEIGHT = 300.dp
 @Composable
 fun NewTransactionForm(modifier: Modifier = Modifier) {
     var showDatePicker by remember { mutableStateOf(false) }
-    var selectedDate by remember { mutableStateOf(Date.now()) }
+    var selectedDate by remember { mutableStateOf(LocalDate.now()) }
     var showLocationPicker by remember { mutableStateOf(false) }
     var selectedLocation by remember { mutableStateOf<Location?>(null) }
     var selectedPrice by remember { mutableStateOf("") }
@@ -100,11 +101,11 @@ fun NewTransactionForm(modifier: Modifier = Modifier) {
             OutlinedTextField(
                 readOnly = true,
                 onValueChange = {},
-                value = selectedDate.toString(),
+                value = selectedDate.formatRelativeToPresent(),
                 shape = MaterialTheme.shapes.medium,
                 trailingIcon = {
                     PlainToolTipBox("Select Date") {
-                        IconButton(onClick = { showDatePicker = !showDatePicker }) {
+                        IconButton(onClick = { showDatePicker = true }) {
                             Icon(painterResource(R.drawable.date_range_24px), "Select Date")
                         }
                     }
@@ -168,7 +169,11 @@ fun NewTransactionForm(modifier: Modifier = Modifier) {
 
     if (showDatePicker) {
         DatePickerDialog(
-            onDismiss = { showDatePicker = false },
+            selectedDate = selectedDate,
+            onDismiss = {
+                @Suppress("AssignedValueIsNeverRead")
+                showDatePicker = false
+            },
             onSubmit = { selectedDate = it },
         )
     }

--- a/android/app/src/main/java/com/example/budgiet/ui/NewTransaction.kt
+++ b/android/app/src/main/java/com/example/budgiet/ui/NewTransaction.kt
@@ -21,8 +21,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Card
-import androidx.compose.material3.DatePicker
-import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
@@ -35,7 +33,6 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -68,6 +65,7 @@ import com.example.budgiet.parsePrice
 import com.example.budgiet.rememberQueryListPager
 import com.example.budgiet.rememberWork
 import com.example.budgiet.ui.theme.BudgietTheme
+import com.example.budgiet.ui.utils.DatePickerDialog
 import com.example.budgiet.ui.utils.FilledTextIconButton
 import com.example.budgiet.ui.utils.ListColumn
 import com.example.budgiet.ui.utils.ListItemScope
@@ -169,35 +167,10 @@ fun NewTransactionForm(modifier: Modifier = Modifier) {
     }
 
     if (showDatePicker) {
-        val datePickerState = rememberDatePickerState(
-            selectableDates = Date.pastOrPresentDates(),
-        )
-
         DatePickerDialog(
-            onDismissRequest = { showDatePicker = false },
-            confirmButton = { TextButton(
-                onClick = {
-                    showDatePicker = false
-                    // FIXME: DatePicker is providing incorrect dates
-                    datePickerState.selectedDateMillis?.let { millis ->
-                        selectedDate = Date(millis)
-                    }
-                }
-            ) {
-                Text("Ok")
-            } },
-            dismissButton = {
-                TextButton(
-                    onClick = { showDatePicker = false }
-                ) {
-                    Text("Cancel")
-                }
-            },
-        ) {
-            DatePicker(
-                state = datePickerState,
-            )
-        }
+            onDismiss = { showDatePicker = false },
+            onSubmit = { selectedDate = it },
+        )
     }
 
     if (showLocationPicker) {

--- a/android/app/src/main/java/com/example/budgiet/ui/utils/Common.kt
+++ b/android/app/src/main/java/com/example/budgiet/ui/utils/Common.kt
@@ -21,11 +21,13 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.getSelectedDate
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
@@ -33,8 +35,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.example.budgiet.Date
 import com.example.budgiet.R
+import com.example.budgiet.localDateFromUtcMillis
+import java.time.LocalDate
 
 /** The space between the [Icon] and the [Text] in [TextIconButton] and [FilledTextIconButton]. */
 val TEXT_ICON_BUTTON_SPACING = 4.dp
@@ -193,11 +196,22 @@ fun PlainSearchBar(
 @Composable
 fun DatePickerDialog(
     modifier: Modifier = Modifier,
+    selectedDate: LocalDate = LocalDate.now(),
     onDismiss: () -> Unit,
-    onSubmit: (Date) -> Unit,
+    onSubmit: (LocalDate) -> Unit,
 ) {
     val datePickerState = rememberDatePickerState(
-        selectableDates = Date.pastOrPresentDates(),
+        initialSelectedDate = selectedDate,
+        /** Only allow [Date][LocalDate]s that occurred.
+         * That is, dates that are in the *past or present*. */
+        selectableDates = object : SelectableDates {
+            override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+                return localDateFromUtcMillis(utcTimeMillis) <= LocalDate.now()
+            }
+            override fun isSelectableYear(year: Int): Boolean {
+                return year <= LocalDate.now().year
+            }
+        },
     )
 
     DatePickerDialog(
@@ -207,10 +221,7 @@ fun DatePickerDialog(
             TextButton(
                 onClick = {
                     onDismiss()
-                    // FIXME: DatePicker is providing incorrect dates
-                    datePickerState.selectedDateMillis?.let { millis ->
-                        onSubmit(Date(millis))
-                    }
+                    onSubmit(datePickerState.getSelectedDate()!!) // There is always a selected date.
                 }
             ) {
                 Text("Ok")

--- a/android/app/src/main/java/com/example/budgiet/ui/utils/Common.kt
+++ b/android/app/src/main/java/com/example/budgiet/ui/utils/Common.kt
@@ -12,6 +12,8 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ButtonElevation
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.DockedSearchBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -24,12 +26,14 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import com.example.budgiet.Date
 import com.example.budgiet.R
 
 /** The space between the [Icon] and the [Text] in [TextIconButton] and [FilledTextIconButton]. */
@@ -183,4 +187,46 @@ fun PlainSearchBar(
             )
         }
     ) { }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DatePickerDialog(
+    modifier: Modifier = Modifier,
+    onDismiss: () -> Unit,
+    onSubmit: (Date) -> Unit,
+) {
+    val datePickerState = rememberDatePickerState(
+        selectableDates = Date.pastOrPresentDates(),
+    )
+
+    DatePickerDialog(
+        modifier = modifier,
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onDismiss()
+                    // FIXME: DatePicker is providing incorrect dates
+                    datePickerState.selectedDateMillis?.let { millis ->
+                        onSubmit(Date(millis))
+                    }
+                }
+            ) {
+                Text("Ok")
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+            ) {
+                Text("Cancel")
+            }
+        },
+    ) {
+        DatePicker(
+            state = datePickerState,
+            showModeToggle = true,
+        )
+    }
 }


### PR DESCRIPTION
Redo of #39.
This solves #28.

When selecting a date from the `DatePickerDialog`, the `TextField` would display the incorrect date. Other times, the app would crash with an Exception saying something like "month 0 is invalid. Valid months are 1 (January) to 12 (December)".

I tried to solve this by trying to interpret the milliseconds in UTC and getting a [`LocalDate`](https://docs.oracle.com/javase/8/docs/api/java/time/LocalDate.html) from there (using our custom `Date` class, which was just a wrapper around `LocalDate`). However I recently found out that this was not necessary because it seems that jetpack compose added a method of [`DatePickerState`](https://developer.android.com/reference/kotlin/androidx/compose/material3/DatePickerState) that returns a `LocalDate`.

We had to upgrade our library versions to use this method. It doesn't say what version it was added, and our `libs.version.toml` did not specify a version for *material3*, but it was definitely not available in the version we were using.
I did not know the method existed because I try not to use the documentation site since it is really ***slow and bloated*** (seriously, sometimes it takes 10 seconds to load a page!). So I tend to use the IDE's auto-completion to see what methods are available for a class, so I thought the only way of getting a `LocalDate` from `DatePickerState` was to process the milliseconds.